### PR TITLE
Convert image-based menus to structured HTML text menus

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -267,3 +267,136 @@ html {
   margin: 4px 20px;
   opacity: 0.6;
 }
+
+/* ===== TEXT MENU ===== */
+.menu-category {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px 16px 8px;
+}
+
+.menu-category-title {
+  text-align: center;
+  font-size: 26px;
+  font-weight: bold;
+  padding: 12px 0;
+  margin: 0;
+  scroll-margin-top: 140px;
+}
+
+.menu-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  background: var(--warm-white);
+  border: 1.5px solid #e8d0a0;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.menu-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 11px 16px;
+  border-bottom: 1px solid #f0e6d0;
+  gap: 12px;
+}
+
+.menu-item:last-child {
+  border-bottom: none;
+}
+
+.menu-item-name {
+  font-size: 15px;
+  color: var(--foreground);
+  line-height: 1.5;
+}
+
+.menu-item-price {
+  font-size: 15px;
+  font-weight: bold;
+  color: var(--primary);
+  white-space: nowrap;
+}
+
+.menu-item-note {
+  font-size: 12px;
+  color: #8b7355;
+}
+
+.menu-note {
+  text-align: center;
+  font-size: 14px;
+  color: #8b7355;
+  padding: 4px 0 8px;
+  margin: 0;
+}
+
+.menu-subcategory {
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--foreground);
+  padding: 10px 16px 4px;
+  background: var(--cream);
+  border-bottom: 1px solid #e8d0a0;
+}
+
+.menu-highlight {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px 16px;
+  text-align: center;
+}
+
+.menu-highlight-card {
+  background: linear-gradient(135deg, #fff9f0, #fdf0d8);
+  border: 2px solid var(--gold);
+  border-radius: 14px;
+  padding: 20px 24px;
+  display: inline-block;
+  text-align: center;
+  box-shadow: 0 4px 16px rgba(201, 149, 12, 0.15);
+}
+
+.menu-price-big {
+  font-size: 28px;
+  font-weight: bold;
+  color: var(--primary);
+}
+
+.menu-price-label {
+  font-size: 14px;
+  color: #8b7355;
+  margin: 0 4px;
+}
+
+.drink-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  background: var(--warm-white);
+  border: 1.5px solid #e8d0a0;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.drink-grid .menu-item {
+  border-right: 1px solid #f0e6d0;
+}
+
+.drink-grid .menu-item:nth-child(2n) {
+  border-right: none;
+}
+
+@media (max-width: 600px) {
+  .drink-grid {
+    grid-template-columns: 1fr;
+  }
+  .drink-grid .menu-item {
+    border-right: none;
+  }
+}

--- a/src/app/menu/otsukare/page.js
+++ b/src/app/menu/otsukare/page.js
@@ -1,23 +1,36 @@
 import Header from "@/app/header";
 import Footer from "@/app/footer";
-import Image from "next/image";
+
+const drinks = [
+  "生ビール（中）1杯",
+  "焼酎1杯",
+  "紹興酒1杯",
+  "日本酒1合",
+  "チューハイ1杯",
+  "ハイボール1杯",
+  "ソフトドリンク2杯",
+];
+
+const twoPinItems = [
+  "焼き餃子", "枝豆", "手羽先煮込み", "ニラレバー", "エビフライ",
+  "冷奴", "唐揚げ", "プチ餃子", "ニラホルモン炒め",
+  "トマトサラダ", "台湾風キュウリ", "棒棒鶏", "叉焼", "回鍋肉",
+  "砂肝", "イカのミックス揚", "ポテトフライ", "麻婆豆腐", "子袋",
+  "ゴボウ揚げ", "シメジ揚げ",
+];
+
+const premiumItems = [
+  "醤油ラーメン", "塩ラーメン",
+  "台湾ラーメン", "豚骨ラーメン",
+  "麻婆飯", "天津飯",
+  "炒飯", "キムチ炒飯",
+];
 
 export default function Otsukare() {
-  const drinks = [
-    "生ビール(中)１杯",
-    "焼酎１杯",
-    "紹興酒１杯",
-    "日本酒１合",
-    "チューハイ１杯",
-    "ハイボール１杯",
-    "ソフトドリンク２杯",
-  ];
-
   return (
     <div>
       <Header />
       <h2
-        id="otsukare"
         style={{
           textAlign: "center",
           fontSize: "20px",
@@ -28,95 +41,65 @@ export default function Otsukare() {
           boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
         }}
       >
-        お疲れ様酒セット（1380円）
+        お疲れ様酒セット
       </h2>
-      <div
-        style={{
-          textAlign: "center",
-          fontSize: "18px",
-          margin: "10px",
-          background: "#f9eed1",
-          borderRadius: "8px",
-        }}
-      >
-        飲み物は下記から１種選べます
-        <ul style={{ listStyle: "none", padding: 0, margin: "10px 0" }}>
-          {drinks.map((drink, idx) => (
-            <li key={idx}>{drink}</li>
-          ))}
-        </ul>
-      </div>
-      <div
-        style={{
-          textAlign: "center",
-          fontSize: "40px",
-        }}
-      >
-        ➕
-      </div>
-      <div
-        style={{
-          margin: "10px",
-          border: "2px solid #e6d3a3",
-          borderRadius: "8px",
-        }}
-      >
-        <div
-          style={{
-            textAlign: "center",
-            fontSize: "18px",
-          }}
-        >
-          料理は下から自由に２品選べます
+
+      <div style={{ paddingBottom: "32px" }}>
+        {/* メイン価格 */}
+        <div className="menu-highlight">
+          <div className="menu-highlight-card">
+            <span className="menu-price-big">1,380円</span>
+            <p style={{ fontSize: "13px", color: "#8b7355", margin: "4px 0 0" }}>
+              お酒1杯 ＋ 料理2品 のお得なセット
+            </p>
+          </div>
         </div>
-        <div
-          style={{ display: "flex", justifyContent: "center", margin: "10px" }}
-        >
-          <Image
-            id="otsukare_2pin"
-            src="/menu/otsukare_2pin.jpeg"
-            alt="お疲れ様酒セット_２品"
-            width={400}
-            height={300}
-            style={{ maxWidth: "100%", height: "auto" }}
-          />
+
+        {/* STEP 1: ドリンク選択 */}
+        <div className="menu-category" style={{ borderTop: "3px solid #9b2d8b" }}>
+          <h2 className="menu-category-title" style={{ color: "#9b2d8b", fontSize: "20px" }}>
+            ① 飲み物を1種選べます
+          </h2>
+          <ul className="menu-items">
+            {drinks.map((drink, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">{drink}</span>
+              </li>
+            ))}
+          </ul>
         </div>
-      </div>
-      <div
-        style={{
-          textAlign: "center",
-          fontSize: "40px",
-        }}
-      >
-        ➕
-      </div>
-      <div
-        style={{
-          margin: "10px",
-          marginBottom: "20px",
-          border: "2px solid #e6d3a3",
-          borderRadius: "8px",
-        }}
-      >
-        <div
-          style={{
-            textAlign: "center",
-            fontSize: "18px",
-          }}
-        >
-          さらに＋400円で下記から１品選べます
+
+        <div style={{ textAlign: "center", fontSize: "36px", padding: "4px 0" }}>➕</div>
+
+        {/* STEP 2: 料理2品 */}
+        <div className="menu-category" style={{ borderTop: "3px solid #EA332F" }}>
+          <h2 className="menu-category-title" style={{ color: "#EA332F", fontSize: "20px" }}>
+            ② 料理を2品選べます
+          </h2>
+          <ul className="drink-grid">
+            {twoPinItems.map((item, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">{item}</span>
+              </li>
+            ))}
+          </ul>
         </div>
-        <div
-          style={{ display: "flex", justifyContent: "center", margin: "10px" }}
-        >
-          <Image
-            id="otsukare_400"
-            src="/menu/otsukare_400.jpeg"
-            alt="お疲れ様酒セット_400円"
-            width={400}
-            height={300}
-            style={{ maxWidth: "100%", height: "auto" }}
-          />
+
+        <div style={{ textAlign: "center", fontSize: "36px", padding: "4px 0" }}>➕</div>
+
+        {/* STEP 3: プレミアム追加 */}
+        <div className="menu-category" style={{ borderTop: "3px solid #F2A93B" }}>
+          <h2 className="menu-category-title" style={{ color: "#F2A93B", fontSize: "20px" }}>
+            ③ さらに＋400円で1品追加
+          </h2>
+          <p className="menu-note">麺類・飯類から1品お選びいただけます</p>
+          <ul className="drink-grid">
+            {premiumItems.map((item, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">{item}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
       <Footer />

--- a/src/app/menu/tabehodai/page.js
+++ b/src/app/menu/tabehodai/page.js
@@ -1,13 +1,59 @@
 import Header from "@/app/header";
 import Footer from "@/app/footer";
-import Image from "next/image";
+
+const foodItems = [
+  "棒棒鶏", "枝豆", "バリバリサラダ", "塩キャベツ",
+  "キムチ", "トマトサラダ", "冷奴", "子袋",
+  "焼き餃子", "唐揚げ", "春巻", "エビフライ",
+  "手羽先煮込み", "ニラレバー", "ポテトフライ", "イカのミックス揚げ",
+  "ゴボウ揚げ", "シメジ揚げ", "鶏皮揚げ", "回鍋肉",
+  "麻婆豆腐", "台湾風キュウリ", "ニラもやし", "エビマヨ",
+  "トマト玉子", "ゴマ豚", "黒酢豚", "酢豚",
+  "ホルモンとニンニク茎炒め", "鶏肉カツ", "鶏カン（中）", "アサリ炒め",
+  "豚肉とキムチ炒め", "野菜炒め",
+  "海鮮お粥", "台湾ラーメン", "豚骨ラーメン", "海鮮ラーメン", "五目ラーメン",
+  "炒飯", "キムチ炒飯", "エビ炒飯", "天津飯",
+];
+
+const drinkCategories = [
+  {
+    name: "ビール",
+    items: ["生中", "瓶ビール"],
+  },
+  {
+    name: "焼酎",
+    items: ["芋（ロック・水割り・お湯割り）", "麦（ロック・水割り・お湯割り）"],
+  },
+  {
+    name: "チューハイ・サワー",
+    items: [
+      "ウーロンハイ", "緑茶ハイ", "パイナップルチューハイ",
+      "レモン", "巨峰", "青リンゴ", "ゆず", "ライム",
+      "梅", "桃", "カシス", "カルピス", "グレープフルーツ",
+    ],
+  },
+  {
+    name: "ウイスキー",
+    items: ["ロック", "ハイボール", "コーラハイボール", "ジンジャーハイボール"],
+  },
+  {
+    name: "果実酒",
+    items: ["杏露酒", "ライチ酒", "梅酒"],
+  },
+  {
+    name: "ソフトドリンク",
+    items: [
+      "コーラ", "メロンソーダ", "カルピス", "緑茶",
+      "烏龍茶", "ジンジャーエール", "オレンジジュース",
+    ],
+  },
+];
 
 export default function Tabehodai() {
   return (
     <div>
       <Header />
       <h2
-        id="tabehodai"
         style={{
           textAlign: "center",
           fontSize: "20px",
@@ -20,35 +66,139 @@ export default function Tabehodai() {
       >
         食べ放題・飲み放題
       </h2>
-      <div
-        id="tabehodai-body"
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <Image
-          src="/menu/tabehodai_1.jpg"
-          alt="食べ放題・飲み放題1"
-          width={600}
-          height={400}
-          style={{ maxWidth: "600px", margin: "20px 0", height: "auto" }}
-        />
-        <Image
-          src="/menu/tabehodai_2.jpg"
-          alt="食べ放題・飲み放題2"
-          width={600}
-          height={400}
-          style={{ maxWidth: "600px", margin: "20px 0", height: "auto" }}
-        />
-        <Image
-          src="/menu/tabehodai_3.jpg"
-          alt="食べ放題・飲み放題3"
-          width={600}
-          height={400}
-          style={{ maxWidth: "600px", margin: "20px 0", height: "auto" }}
-        />
+
+      <div style={{ paddingBottom: "32px" }}>
+        {/* 料金プラン */}
+        <div className="menu-highlight" style={{ paddingTop: "24px" }}>
+          <div
+            className="menu-highlight-card"
+            style={{ maxWidth: "500px", width: "100%" }}
+          >
+            <p
+              style={{
+                fontSize: "20px",
+                fontWeight: "bold",
+                color: "#5e503f",
+                margin: "0 0 4px",
+              }}
+            >
+              食べ放題 ＋ 飲み放題
+            </p>
+            <p style={{ fontSize: "13px", color: "#8b7355", margin: "0 0 8px" }}>
+              2時間制 ／ 5名様より ／ 会計制
+            </p>
+            <div style={{ margin: "8px 0" }}>
+              <span className="menu-price-label">大人・高校生</span>
+              <span className="menu-price-big">3,980円</span>
+            </div>
+            <p style={{ fontSize: "13px", color: "#8b7355", margin: "0 0 4px" }}>
+              中学生以下 2,280円
+            </p>
+          </div>
+        </div>
+
+        <div className="menu-category" style={{ borderTop: "none", paddingTop: "0" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: "12px",
+              justifyContent: "center",
+              flexWrap: "wrap",
+              margin: "8px 0 20px",
+            }}
+          >
+            <div
+              style={{
+                background: "var(--warm-white)",
+                border: "1.5px solid #e8d0a0",
+                borderRadius: "12px",
+                padding: "14px 20px",
+                textAlign: "center",
+                flex: "1",
+                minWidth: "180px",
+              }}
+            >
+              <p style={{ fontWeight: "bold", fontSize: "15px", color: "#5e503f", margin: "0 0 4px" }}>
+                食べ放題のみ
+              </p>
+              <p style={{ fontSize: "13px", color: "#8b7355", margin: "0 0 4px" }}>2時間・5名様より</p>
+              <p style={{ fontWeight: "bold", fontSize: "20px", color: "var(--primary)", margin: 0 }}>
+                3,280円
+              </p>
+            </div>
+            <div
+              style={{
+                background: "var(--warm-white)",
+                border: "1.5px solid #e8d0a0",
+                borderRadius: "12px",
+                padding: "14px 20px",
+                textAlign: "center",
+                flex: "1",
+                minWidth: "180px",
+              }}
+            >
+              <p style={{ fontWeight: "bold", fontSize: "15px", color: "#5e503f", margin: "0 0 4px" }}>
+                飲み放題のみ
+              </p>
+              <p style={{ fontSize: "13px", color: "#8b7355", margin: "0 0 4px" }}>2時間・5名様より</p>
+              <p style={{ fontWeight: "bold", fontSize: "20px", color: "var(--primary)", margin: 0 }}>
+                2,980円
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* 食べ放題メニュー */}
+        <div className="menu-category" style={{ borderTop: "3px solid #EA332F", paddingTop: "8px" }}>
+          <h2
+            className="menu-category-title"
+            style={{ color: "#EA332F" }}
+          >
+            食べ放題メニュー
+          </h2>
+          <ul className="drink-grid">
+            {foodItems.map((item, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">{item}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="menu-note" style={{ paddingTop: "8px" }}>
+            ※ その他多数のメニューがございます。詳しくは店内でご確認ください。
+          </p>
+        </div>
+
+        {/* 飲み放題メニュー */}
+        <div className="menu-category" style={{ borderTop: "3px solid #F2A93B", paddingTop: "8px" }}>
+          <h2
+            className="menu-category-title"
+            style={{ color: "#F2A93B" }}
+          >
+            飲み放題メニュー
+          </h2>
+          {drinkCategories.map((cat, ci) => (
+            <div key={ci} style={{ marginBottom: "12px" }}>
+              <p
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "15px",
+                  color: "#5e503f",
+                  textAlign: "center",
+                  margin: "12px 0 4px",
+                }}
+              >
+                {cat.name}
+              </p>
+              <ul className="drink-grid">
+                {cat.items.map((item, idx) => (
+                  <li key={idx} className="menu-item">
+                    <span className="menu-item-name">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
       </div>
       <Footer />
     </div>

--- a/src/app/menu/tanpin/page.js
+++ b/src/app/menu/tanpin/page.js
@@ -2,14 +2,359 @@ import React from "react";
 import Header from "@/app/header";
 import Footer from "@/app/footer";
 import Link from "next/link";
-import Image from "next/image";
+
+const menuData = [
+  {
+    id: "zensai",
+    title: "前菜",
+    color: "#EA332F",
+    items: [
+      { name: "棒棒鶏", price: "680円" },
+      { name: "野菜サラダ", price: "680円" },
+      { name: "台湾風キュウリ", price: "580円" },
+      { name: "幻肝のタレ", price: "580円" },
+      { name: "生春巻", price: "580円" },
+      { name: "枝豆", price: "480円" },
+      { name: "バリバリサラダ", price: "780円" },
+      { name: "塩キャベツ", price: "480円" },
+      { name: "キムチ", price: "580円" },
+      { name: "トマトサラダ", price: "580円" },
+      { name: "冷奴", price: "780円" },
+      { name: "子袋", price: "780円" },
+      { name: "キュウリの黒胡椒和え", price: "680円" },
+      { name: "砂肝（3串）", price: "580円" },
+      { name: "台湾風の煮込み", price: "680円" },
+      { name: "卵クレープ", price: "580円" },
+    ],
+  },
+  {
+    id: "agemono",
+    title: "揚げ物",
+    color: "#DE742D",
+    items: [
+      { name: "春巻", price: "680円" },
+      { name: "若鶏の唐揚げ（7個）", price: "680円" },
+      { name: "若鶏の唐揚げ（3個）", price: "400円" },
+      { name: "ポテトフライ", price: "580円" },
+      { name: "イカのミックス揚げ", price: "680円" },
+      { name: "手羽先の唐揚げ", price: "580円" },
+      { name: "チーズ春巻（5本）", price: "580円" },
+      { name: "鯛魚骨唐揚げ", price: "580円" },
+      { name: "シメジ揚げ", price: "580円" },
+      { name: "ゴボウ揚げ", price: "580円" },
+      { name: "レバニラ揚", price: "780円" },
+      { name: "ジャガイモ揚バター", price: "680円" },
+      { name: "海エビ揚げ", price: "580円" },
+      { name: "鶏皮揚げ", price: "580円" },
+    ],
+  },
+  {
+    id: "niku",
+    title: "肉料理",
+    color: "#D15F27",
+    items: [
+      { name: "牛肉の四川風煮込み", price: "1280円" },
+      { name: "豚肉のニンニク茎炒め", price: "980円" },
+      { name: "黒酢豚", price: "980円" },
+      { name: "酢豚", price: "880円" },
+      { name: "回鍋肉", price: "880円" },
+      { name: "ゴマ豚", price: "980円" },
+      { name: "台湾風腸詰", price: "1080円" },
+      { name: "ニラレバー", price: "880円" },
+      { name: "ホルモンとニンニク茎炒め", price: "980円" },
+      { name: "黄ニラ豚", price: "880円" },
+      { name: "油淋鶏", price: "880円" },
+      { name: "砂肝の黒胡椒炒め", price: "880円" },
+      { name: "ホルモンとキノコしめじ", price: "880円" },
+      { name: "キクラゲと豚肉炒め", price: "880円" },
+      { name: "豚肉の生姜焼", price: "980円" },
+      { name: "牛肉の黒胡椒炒め", price: "1080円" },
+      { name: "トンマヨ", price: "880円" },
+      { name: "鶏肉の甘酢和え", price: "980円" },
+      { name: "鶏肉カツ", price: "880円" },
+      { name: "豚カツ", price: "880円" },
+    ],
+  },
+  {
+    id: "yasai",
+    title: "野菜料理",
+    color: "#4E8326",
+    items: [
+      { name: "地獄麻婆豆腐", price: "1280円" },
+      { name: "焼きビーフン", price: "780円" },
+      { name: "カニ玉子", price: "880円" },
+      { name: "ニラもやし", price: "780円" },
+      { name: "四川麻婆豆腐", price: "880円" },
+      { name: "トマトと玉子炒め", price: "880円" },
+      { name: "味噌なす", price: "880円" },
+      { name: "野菜炒め", price: "780円" },
+      { name: "青菜炒め", price: "880円" },
+      { name: "麻婆春雨", price: "780円" },
+      { name: "麻婆ナス", price: "880円" },
+      { name: "八宝菜", price: "880円" },
+      { name: "麻婆豆腐", price: "780円" },
+    ],
+  },
+  {
+    id: "kaisen",
+    title: "海鮮料理",
+    color: "#53B7E3",
+    items: [
+      { name: "エビチリ", price: "1080円" },
+      { name: "エビマヨ", price: "1080円" },
+      { name: "アサリ炒め", price: "980円" },
+      { name: "カキの黒胡椒炒め", price: "980円" },
+      { name: "エビ青梗菜炒め", price: "980円" },
+    ],
+  },
+  {
+    id: "teppan",
+    title: "鉄板",
+    color: "#E33231",
+    items: [
+      { name: "牛すじの鉄板焼き", price: "1080円" },
+      { name: "鉄板豚肉とキムチ炒め", price: "980円" },
+      { name: "牛ホルモンの鉄板焼き", price: "1080円" },
+      { name: "鉄板香辣エビ", price: "1180円" },
+      { name: "鉄板野菜豆腐", price: "880円" },
+      { name: "鉄板骨なし鶏肉", price: "980円" },
+    ],
+  },
+  {
+    id: "tenshin",
+    title: "点心",
+    color: "#E1AA3A",
+    items: [
+      { name: "焼き餃子", price: "280円" },
+      { name: "鉄板棒餃子", price: "730円" },
+      { name: "水餃子", price: "780円" },
+      { name: "小籠包", price: "480円" },
+      { name: "シューマイ", price: "680円" },
+      { name: "揚げ餃子", price: "580円" },
+      { name: "エビ餃子", price: "480円" },
+      { name: "ココナッツ団子", price: "550円" },
+      { name: "もも饅頭", price: "520円" },
+      { name: "ゴマ団子", price: "580円" },
+      { name: "バニラアイスクリーム", price: "380円" },
+      { name: "杏仁豆腐", price: "380円" },
+    ],
+  },
+  {
+    id: "okayu",
+    title: "お粥・スープ",
+    color: "#DCAA3B",
+    items: [
+      { name: "たまごスープ", price: "380円" },
+      { name: "野菜お粥", price: "680円" },
+      { name: "海鮮お粥", price: "780円" },
+      { name: "コーンスープ", price: "680円" },
+      { name: "ワンタンスープ", price: "680円" },
+    ],
+  },
+  {
+    id: "menrui",
+    title: "麺類",
+    color: "#D65F28",
+    items: [
+      { name: "麻辣麺", price: "980円" },
+      { name: "五目パリそば", price: "980円" },
+      { name: "味噌ラーメン", price: "830円" },
+      { name: "中華冷やそば", price: "880円" },
+      { name: "豚骨ラーメン", price: "830円" },
+      { name: "台湾ラーメン", price: "830円" },
+      { name: "担々麺", price: "880円" },
+      { name: "醤油ラーメン", price: "830円" },
+      { name: "特製台湾ラーメン", price: "880円" },
+      { name: "台湾豚骨ラーメン", price: "730円" },
+      { name: "塩ラーメン", price: "830円" },
+      { name: "海鮮ラーメン", price: "780円" },
+      { name: "天津麺", price: "780円" },
+      { name: "四川ラーメン", price: "830円" },
+      { name: "ネギラーメン", price: "830円" },
+      { name: "五目ラーメン", price: "830円" },
+      { name: "天津ラーメン", price: "830円" },
+      { name: "韓国冷麺", price: "880円" },
+      { name: "焼肉冷やそば", price: "880円" },
+      { name: "台湾まぜそば", price: "880円" },
+      { name: "五目あんかけそば", price: "880円" },
+    ],
+  },
+  {
+    id: "hanrui",
+    title: "飯類",
+    color: "#CF2D24",
+    note: "ライス：（大）400円 ／（中）300円 ／（小）200円",
+    items: [
+      { name: "味噌飯", price: "830円" },
+      { name: "豚バラ炒飯", price: "960円" },
+      { name: "炒飯", price: "880円" },
+      { name: "レタス炒飯", price: "880円" },
+      { name: "ニンニク炒飯", price: "880円" },
+      { name: "キムチ炒飯", price: "880円" },
+      { name: "エビ炒飯", price: "880円" },
+      { name: "五目炒飯", price: "880円" },
+      { name: "麻婆飯", price: "880円" },
+      { name: "天津飯", price: "880円" },
+      { name: "南蛮天津飯", price: "980円" },
+      { name: "カツ丼", price: "980円" },
+      { name: "唐揚げ丼", price: "980円" },
+      { name: "中華丼", price: "880円" },
+      { name: "牛丼", price: "880円" },
+    ],
+  },
+  {
+    id: "alcohol",
+    title: "アルコール",
+    color: "#F2A93B",
+    subcategories: [
+      {
+        name: "ビール",
+        items: [
+          { name: "生ビール（中）", price: "480円" },
+          { name: "瓶ビール（大）", price: "580円" },
+          { name: "男気ジョッキ", price: "750円" },
+          { name: "アサヒスーパードライ", price: "750円" },
+          { name: "ノンアルコールビール", price: "350円" },
+        ],
+      },
+      {
+        name: "焼酎（ロック・水割り・お湯割り）",
+        items: [
+          { name: "芋", price: "各390円" },
+          { name: "麦", price: "各390円" },
+        ],
+      },
+      {
+        name: "日本酒",
+        items: [
+          { name: "伏見鶴（一合）", price: "450円" },
+          { name: "冷酒", price: "800円" },
+        ],
+      },
+      {
+        name: "果実酒（ロック）",
+        items: [
+          { name: "杏露酒", price: "各350円" },
+          { name: "ライチ酒", price: "各350円" },
+          { name: "酸梅酒（梅酒）", price: "各350円" },
+        ],
+      },
+      {
+        name: "中国酒",
+        items: [
+          { name: "紹興酒", price: "各350円" },
+          { name: "花彫酒", price: "各350円" },
+        ],
+      },
+      {
+        name: "チューハイ",
+        items: [
+          { name: "ウーロンハイ", price: "各480円" },
+          { name: "緑茶ハイ", price: "各480円" },
+          { name: "パイナップルチューハイ", price: "各480円" },
+          { name: "レモン", price: "各480円" },
+          { name: "巨峰", price: "各480円" },
+          { name: "青リンゴ", price: "各480円" },
+          { name: "ゆず", price: "各480円" },
+          { name: "ライム", price: "各480円" },
+          { name: "梅", price: "各480円" },
+          { name: "桃", price: "各480円" },
+          { name: "カシス", price: "各480円" },
+          { name: "カルピス", price: "各480円" },
+          { name: "グレープフルーツ", price: "各480円" },
+        ],
+      },
+      {
+        name: "サワー",
+        items: [
+          { name: "生レモンサワー", price: "530円" },
+          { name: "その他サワー", price: "各450円" },
+        ],
+      },
+      {
+        name: "ウイスキー",
+        items: [
+          { name: "ロック", price: "530円" },
+          { name: "ハイボール", price: "350円" },
+          { name: "コーラハイボール", price: "350円" },
+          { name: "ジンジャーハイボール", price: "350円" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "drink",
+    title: "ソフトドリンク",
+    color: "#F0AC3F",
+    note: "基本 各250円",
+    items: [
+      { name: "コーラ", price: "250円" },
+      { name: "オレンジジュース", price: "250円" },
+      { name: "メロン", price: "250円" },
+      { name: "コーヒー", price: "250円" },
+      { name: "カルピス", price: "250円" },
+      { name: "緑茶", price: "250円" },
+      { name: "烏龍茶", price: "250円" },
+      { name: "ジンジャーエール", price: "250円" },
+      { name: "マンゴージュース", price: "350円" },
+      { name: "マンゴーオレンジ", price: "350円" },
+      { name: "マンゴーカルピス", price: "350円" },
+    ],
+  },
+];
+
+function MenuCategory({ category }) {
+  return (
+    <div
+      className="menu-category"
+      style={{ borderTop: `3px solid ${category.color}` }}
+    >
+      <h2
+        id={category.id}
+        className="menu-category-title"
+        style={{ color: category.color }}
+      >
+        {category.title}
+      </h2>
+      {category.note && <p className="menu-note">{category.note}</p>}
+      {category.subcategories ? (
+        <ul className="menu-items">
+          {category.subcategories.map((sub, si) => (
+            <React.Fragment key={si}>
+              <li className="menu-subcategory">{sub.name}</li>
+              {sub.items.map((item, idx) => (
+                <li key={idx} className="menu-item">
+                  <span className="menu-item-name">{item.name}</span>
+                  <span className="menu-item-price">{item.price}</span>
+                </li>
+              ))}
+            </React.Fragment>
+          ))}
+        </ul>
+      ) : (
+        <ul className="menu-items">
+          {category.items.map((item, idx) => (
+            <li key={idx} className="menu-item">
+              <span className="menu-item-name">{item.name}</span>
+              <span className="menu-item-price">{item.price}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 export default function Menu() {
+  const categories = [
+    "前菜", "揚げ物", "肉料理", "野菜料理", "海鮮料理", "鉄板",
+    "点心", "お粥・スープ", "麺類", "飯類", "アルコール", "ドリンク",
+  ];
+
   return (
     <div>
       <Header />
       <h2
-        id="tanpin"
         style={{
           textAlign: "center",
           fontSize: "20px",
@@ -20,10 +365,9 @@ export default function Menu() {
           boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
         }}
       >
-        単品
+        単品メニュー
       </h2>
-      <div
-        id="menu-header"
+      <nav
         style={{
           background: "#f9eed1",
           color: "#5e503f",
@@ -44,333 +388,21 @@ export default function Menu() {
             listStyle: "none",
           }}
         >
-          <li>
-            <Link href="#zensai">
-              <h3 style={{ borderBottom: "1px solid" }}>前菜</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#agemono">
-              <h3 style={{ borderBottom: "1px solid" }}>揚げ物</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#niku">
-              <h3 style={{ borderBottom: "1px solid" }}>肉料理</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#yasai">
-              <h3 style={{ borderBottom: "1px solid" }}>野菜料理</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#kaisen">
-              <h3 style={{ borderBottom: "1px solid" }}>海鮮料理</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#teppan">
-              <h3 style={{ borderBottom: "1px solid" }}>鉄板</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#tenshin">
-              <h3 style={{ borderBottom: "1px solid" }}>点心</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#okayu">
-              <h3 style={{ borderBottom: "1px solid" }}>お粥・スープ</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#menrui">
-              <h3 style={{ borderBottom: "1px solid" }}>麺類</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#hanrui">
-              <h3 style={{ borderBottom: "1px solid" }}>飯類</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#alcohol">
-              <h3 style={{ borderBottom: "1px solid" }}>アルコール</h3>
-            </Link>
-          </li>
-          <li>
-            <Link href="#drink">
-              <h3 style={{ borderBottom: "1px solid" }}>ドリンク</h3>
-            </Link>
-          </li>
+          {menuData.map((cat) => (
+            <li key={cat.id}>
+              <Link href={`#${cat.id}`}>
+                <h3 style={{ borderBottom: "1px solid", fontWeight: "bold" }}>
+                  {cat.id === "drink" ? "ドリンク" : cat.title}
+                </h3>
+              </Link>
+            </li>
+          ))}
         </ul>
-      </div>
-      <div id="menu" style={{ textAlign: "center", margin: "32px 0" }}>
-        {/* 前菜 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #EA332F",
-          }}
-        >
-          <h2
-            id="zensai"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#EA332F",
-            }}
-          >
-            前菜
-          </h2>
-          <Image src="/menu/zensai.jpeg" alt="前菜" width={400} height={300} />
-        </div>
-        {/* 揚げ物 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #DE742D",
-          }}
-        >
-          <h2
-            id="agemono"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#DE742D",
-            }}
-          >
-            揚げ物
-          </h2>
-          <Image src="/menu/agemono.jpeg" alt="揚げ物" width={400} height={300} />
-        </div>
-        {/* 肉料理 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #D15F27",
-          }}
-        >
-          <h2
-            id="niku"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#D15F27",
-            }}
-          >
-            肉料理
-          </h2>
-          <Image src="/menu/niku.jpeg" alt="肉料理" width={400} height={300} />
-        </div>
-        {/* 野菜料理 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #4E8326",
-          }}
-        >
-          <h2
-            id="yasai"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#4E8326",
-            }}
-          >
-            野菜料理
-          </h2>
-          <Image src="/menu/yasai.jpeg" alt="野菜料理" width={400} height={300} />
-        </div>
-        {/* 海鮮料理 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #53B7E3",
-          }}
-        >
-          <h2
-            id="kaisen"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#53B7E3",
-            }}
-          >
-            海鮮料理
-          </h2>
-          <Image src="/menu/kaisen.jpeg" alt="海鮮料理" width={400} height={300} />
-        </div>
-        {/* 鉄板 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #E33231",
-          }}
-        >
-          <h2
-            id="teppan"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#E33231",
-            }}
-          >
-            鉄板
-          </h2>
-          <Image src="/menu/teppan.jpeg" alt="鉄板" width={400} height={300} />
-        </div>
-        {/* 点心 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #E1AA3A",
-          }}
-        >
-          <h2
-            id="tenshin"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#E1AA3A",
-            }}
-          >
-            点心
-          </h2>
-          <Image src="/menu/tenshin.jpeg" alt="点心" width={400} height={300} />
-        </div>
-        {/* お粥・スープ */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #DCAA3B",
-          }}
-        >
-          <h2
-            id="okayu"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#DCAA3B",
-            }}
-          >
-            お粥・スープ
-          </h2>
-          <Image src="/menu/okayu.jpeg" alt="お粥・スープ" width={400} height={300} />
-        </div>
-        {/* 麺類 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #D65F28",
-          }}
-        >
-          <h2
-            id="menrui"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#D65F28",
-            }}
-          >
-            麺類
-          </h2>
-          <Image src="/menu/menrui.jpeg" alt="麺類" width={400} height={300} />
-        </div>
-        {/* 飯類 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #CF2D24",
-          }}
-        >
-          <h2
-            id="hanrui"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#CF2D24",
-            }}
-          >
-            飯類
-          </h2>
-          <Image src="/menu/hanrui.jpeg" alt="飯類" width={400} height={300} />
-        </div>
-        {/* アルコール */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #F2A93B",
-          }}
-        >
-          <h2
-            id="alcohol"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#F2A93B",
-            }}
-          >
-            アルコール
-          </h2>
-          <Image src="/menu/alcohol.jpeg" alt="アルコール" width={400} height={300} />
-        </div>
-        {/* ドリンク */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #F0AC3F",
-          }}
-        >
-          <h2
-            id="drink"
-            style={{
-              scrollMarginTop: "170px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#F0AC3F",
-            }}
-          >
-            ドリンク
-          </h2>
-          <Image src="/menu/drink.jpeg" alt="ドリンク" width={400} height={300} />
-        </div>
+      </nav>
+      <div style={{ paddingBottom: "32px" }}>
+        {menuData.map((category) => (
+          <MenuCategory key={category.id} category={category} />
+        ))}
       </div>
       <Footer />
     </div>

--- a/src/app/menu/teisyoku/page.js
+++ b/src/app/menu/teisyoku/page.js
@@ -1,14 +1,68 @@
 import Header from "@/app/header";
 import Footer from "@/app/footer";
 import Link from "next/link";
-import Image from "next/image";
+
+const lunchItems = [
+  "エビチリ",
+  "エビマヨ",
+  "ニラレバー",
+  "回鍋肉",
+  "八宝菜",
+  "台湾風酢豚",
+  "油淋鶏",
+  "カニ玉子",
+  "麻婆春雨",
+  "キクラゲ玉子エビかけ",
+  "麻婆豆腐",
+  "ニラもやし",
+  "野菜炒め",
+  "青椒肉絲",
+  "麻婆ナス",
+  "味噌ナス",
+  "ナスと鶏肉炒め",
+];
+
+const teisyokuItems = [
+  { name: "台湾ラーメン定食", price: "1360円" },
+  { name: "醤油ラーメン定食", price: "1360円" },
+  { name: "黄ニラ豚定食", price: "1100円" },
+  { name: "麻婆定食", price: "1360円" },
+  { name: "水餃子定食", price: "1100円" },
+  { name: "鶏肉カツ定食", price: "1380円" },
+  { name: "豚カツ定食", price: "1380円" },
+  { name: "エビマヨ定食", price: "1180円" },
+  { name: "エビチリ定食", price: "1180円" },
+];
+
+const setMenuItems = [
+  {
+    name: "ラーメンセット",
+    note: "各種ラーメン＋ミニ炒飯 or ライス",
+    items: [
+      { name: "醤油ラーメン", price: "830円" },
+      { name: "味噌ラーメン", price: "830円" },
+      { name: "塩ラーメン", price: "830円" },
+      { name: "豚骨ラーメン", price: "830円" },
+      { name: "台湾ラーメン", price: "830円" },
+      { name: "特製台湾ラーメン", price: "880円" },
+    ],
+  },
+  {
+    name: "サイドセット",
+    items: [
+      { name: "餃子セット（6個）", price: "280円" },
+      { name: "ご飯セット", price: "280円" },
+      { name: "唐揚げセット（3個）", price: "380円" },
+      { name: "唐揚げセット（5個）", price: "480円" },
+    ],
+  },
+];
 
 export default function Teisyoku() {
   return (
     <div>
       <Header />
-      <div
-        id="teisyoku-header"
+      <nav
         style={{
           textAlign: "center",
           fontSize: "20px",
@@ -34,105 +88,117 @@ export default function Teisyoku() {
         >
           <li>
             <Link href="#lunch">
-              <h3 style={{ borderBottom: "1px solid" }}>ランチ</h3>
+              <h3 style={{ borderBottom: "1px solid", fontWeight: "bold" }}>ランチ</h3>
             </Link>
           </li>
           <li>
-            <Link href="#teiysoku">
-              <h3 style={{ borderBottom: "1px solid" }}>定食</h3>
+            <Link href="#teisyoku">
+              <h3 style={{ borderBottom: "1px solid", fontWeight: "bold" }}>定食</h3>
             </Link>
           </li>
           <li>
             <Link href="#set">
-              <h3 style={{ borderBottom: "1px solid" }}>セット</h3>
+              <h3 style={{ borderBottom: "1px solid", fontWeight: "bold" }}>セット</h3>
             </Link>
           </li>
         </ul>
-      </div>
-      <div id="teisyoku-body" style={{ textAlign: "center", margin: "32px 0" }}>
+      </nav>
+
+      <div style={{ paddingBottom: "32px" }}>
         {/* ランチ */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #EA332F",
-          }}
-        >
+        <div className="menu-category" style={{ borderTop: "3px solid #EA332F" }}>
           <h2
             id="lunch"
-            style={{
-              scrollMarginTop: "70px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#EA332F",
-            }}
+            className="menu-category-title"
+            style={{ color: "#EA332F", scrollMarginTop: "100px" }}
           >
-            ランチ
+            ランチメニュー
           </h2>
-          <Image
-            src="/menu/lunch.jpeg"
-            alt="ランチ"
-            width={400}
-            height={300}
-            style={{ maxWidth: "100%", height: "auto" }}
-          />
+          <div className="menu-highlight" style={{ padding: "0 0 12px" }}>
+            <div className="menu-highlight-card">
+              <div>
+                <span className="menu-price-label">昼</span>
+                <span className="menu-price-big">900円</span>
+                <span style={{ margin: "0 12px", color: "#8b7355" }}>／</span>
+                <span className="menu-price-label">夜</span>
+                <span className="menu-price-big">1,100円</span>
+              </div>
+              <p style={{ fontSize: "13px", color: "#8b7355", margin: "8px 0 0" }}>
+                ライス（小・中・大）自由 ／ コーヒー1杯サービス
+              </p>
+            </div>
+          </div>
+          <p className="menu-note">
+            一品料理・揚げ物・漬物・杏仁豆腐・ライス・スープ付き
+          </p>
+          <p className="menu-note" style={{ paddingBottom: "4px" }}>
+            下記から1品お選びください
+          </p>
+          <ul className="menu-items">
+            {lunchItems.map((item, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">
+                  {idx + 1}. {item}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
+
         {/* 定食 */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #DE742D",
-          }}
-        >
+        <div className="menu-category" style={{ borderTop: "3px solid #DE742D" }}>
           <h2
-            id="teiysoku"
-            style={{
-              scrollMarginTop: "70px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#DE742D",
-            }}
+            id="teisyoku"
+            className="menu-category-title"
+            style={{ color: "#DE742D", scrollMarginTop: "100px" }}
           >
             定食
           </h2>
-          <Image
-            src="/menu/teisyoku.jpeg"
-            alt="定食"
-            width={400}
-            height={300}
-            style={{ maxWidth: "100%", height: "auto" }}
-          />
+          <ul className="menu-items">
+            {teisyokuItems.map((item, idx) => (
+              <li key={idx} className="menu-item">
+                <span className="menu-item-name">{item.name}</span>
+                <span className="menu-item-price">{item.price}</span>
+              </li>
+            ))}
+          </ul>
         </div>
+
         {/* セット */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            borderTop: "2px solid #D15F27",
-          }}
-        >
+        <div className="menu-category" style={{ borderTop: "3px solid #D15F27" }}>
           <h2
             id="set"
-            style={{
-              scrollMarginTop: "70px",
-              textAlign: "center",
-              fontSize: "30px",
-              color: "#D15F27",
-            }}
+            className="menu-category-title"
+            style={{ color: "#D15F27", scrollMarginTop: "100px" }}
           >
             セット
           </h2>
-          <Image
-            src="/menu/set.jpeg"
-            alt="セット"
-            width={400}
-            height={300}
-            style={{ maxWidth: "100%", height: "auto" }}
-          />
+          {setMenuItems.map((section, si) => (
+            <div key={si} style={{ marginBottom: "16px" }}>
+              <p
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "16px",
+                  color: "#5e503f",
+                  textAlign: "center",
+                  margin: "12px 0 4px",
+                }}
+              >
+                {section.name}
+              </p>
+              {section.note && (
+                <p className="menu-note">{section.note}</p>
+              )}
+              <ul className="menu-items">
+                {section.items.map((item, idx) => (
+                  <li key={idx} className="menu-item">
+                    <span className="menu-item-name">{item.name}</span>
+                    <span className="menu-item-price">{item.price}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
Replace JPEG menu images with searchable, accessible HTML text for all
four menu pages (tanpin, teisyoku, tabehodai, otsukare). This improves
SEO indexability, screen reader accessibility, and mobile readability.
Menu data is structured as JS arrays for easy future updates.

https://claude.ai/code/session_01DbqJ5R6LuWfWWMhT5gNDb1